### PR TITLE
Allow init.sql location to be customized

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ This Docker image has a number of volume mount points in addition to `/data`. He
 
 ## How to initialize this container with a SQL file?
 
-When this docker image starts for the first time it will check to see if `/init.sql` exists in its filesystem. If `/init.sql` is found, the container will run it against the database as soon as SingleStoreDB is ready.
+When this docker image starts for the first time it will check to see if an `init.sql` file exists in its filesystem. The default location is `/init.sh`, but it can be customized via the `INIT_SQL` environment variable. If `init.sql` is found, the container will run it against the database as soon as SingleStoreDB is ready.
 
 One way to do this is mounting a `init.sql` from your machine into the container using the `-v` flag. Here is an example of doing this:
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -73,10 +73,12 @@ for var in "${!SINGLESTORE_SET_GLOBAL_@}"; do
         --key "${var}" --value "${val}"
 done
 
+INIT_SQL="${INIT_SQL:-/init.sql}"
+
 # run init.sql if it exists (and we haven't already run it)
-if [[ -f /init.sql && ! -f /data/.init.sql.done ]]; then
+if [[ -f "${INIT_SQL}" && ! -f /data/.init.sql.done ]]; then
     echo "Running init.sql..."
-    singlestore -p${ROOT_PASSWORD} </init.sql
+    singlestore -p${ROOT_PASSWORD} < "${INIT_SQL}"
     touch /data/.init.sql.done
 fi
 


### PR DESCRIPTION
This should be useful if init.sql exists in a volume, and the entire volume is mounted.