### PR TITLE
Use sdb-admin to set global variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN yum makecache --refresh && \
     yum install -y yum-utils wget procps && \
     yum update -y curl && \
     yum-config-manager --save --setopt=skip_missing_names_on_install=0 && \
-    yum -y update-minimal --setopt=tsflags=nodocs --security --sec-severity=Important --sec-severity=Critical && \
+    yum -y update-minimal --setopt=tsflags=nodocs --nobest --security --sec-severity=Important --sec-severity=Critical && \
     dnf --enablerepo=* clean all && \
     dnf update -y && \
     yum remove -y vim-minimal platform-python-pip.noarch && \

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -68,8 +68,7 @@ for var in "${!SINGLESTORE_SET_GLOBAL_@}"; do
     var="${var,,}"
 
     echo "Setting ${var} to ${val}"
-    memsqlctl -jy update-config \
-        --memsql-id ${MASTER_ID} --set-global --detailed-output \
+    sdb-admin -jy update-config --set-global --all \
         --key "${var}" --value "${val}"
 done
 


### PR DESCRIPTION
We were simply setting global variables in the MA using memsqlctl. This of course means we are not setting variables for leaves. This isn't a problem for most recent variables, which are sync vars, but can be a problem for non-sync ones.

In my case, I was running the singlestore-dev image in a pretty big machine, which made the default maximum_memory too big for the free license. Setting the maximum_memory at the MA level wasn't enough.

Manually tested by deploying the image and changing variables.