### PR TITLE
[singlestoredb-dev-image] Bumps the engine version to 8.5.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.15 - 2024-03-19
+ - SingleStoreDB Version 8.5.12
+
 ## 0.2.14 - 2024-03-13
  - SingleStoreDB Version 8.5.11
 

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "channel": "production",
-  "server": "8.5.11-b906f298a2",
+  "server": "8.5.12-f8b7fb3b86",
   "toolbox": "1.17.4",
   "client": "1.0.7",
   "studio": "4.0.14"


### PR DESCRIPTION
8.5.12 release