### PR TITLE
Make sure gpg keys are updated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,6 +126,11 @@ jobs:
           SINGLESTORE_LICENSE: ${{ secrets.SINGLESTORE_LICENSE }}
 
     steps:
+      - name: free up disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+            tool-cache: false
+
       - name: sanity check using mysql client
         run: |
           mysql -u root -ptest -e "SELECT 1" -h 127.0.0.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM almalinux:8.6-20220901
 
 ARG SECURITY_UPDATES_AS_OF=2022-09-30
 
+RUN dnf upgrade -y almalinux-release && \
+    yum -y clean all
+
 RUN yum makecache --refresh && \
     yum install -y yum-utils wget procps java-11-openjdk && \
     yum update -y curl && \


### PR DESCRIPTION
- Pull latest gpg keys for alma before doing installing anything.

- New packages took up more disk space, so test runner began failing.  Added a step to free up excess space.