### PR TITLE
PLAT-7287 Updated singlestoredb-dev image to properly match version on container restart.

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -30,9 +30,8 @@ fi
 # check to see if we need to switch versions at runtime
 if [ -n "${SINGLESTORE_VERSION-}" ]; then
     CURRENT_VERSION=$(memsqlctl -j version | jq -r '"\(.version)-\(.commitHash[0:10])"')
-    TARGET_VERSION="${SINGLESTORE_VERSION%%:*}"
-    if [ "${CURRENT_VERSION}" != "${TARGET_VERSION}" ]; then
-        echo "Switching SingleStore version from '${CURRENT_VERSION}' to '${TARGET_VERSION}'"
+    if [[ "$CURRENT_VERSION" != "$SINGLESTORE_VERSION"* ]]; then
+        echo "Switching SingleStore version from '${CURRENT_VERSION}' to '${SINGLESTORE_VERSION}'"
         /scripts/switch-version.sh "${SINGLESTORE_VERSION}" "${SINGLESTORE_LICENSE}"
     fi
 fi


### PR DESCRIPTION
**Issue:**
When specifying a SingleStoreDB version at runtime as SINGLESTORE_VERSION without a hash (e.g., 8.1, 8.9), it will be detected as a different version upon container restart, and all nodes will be recreated.