### PR TITLE
Add mongosh client to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,13 @@ RUN wget --no-check-certificate https://raw.githubusercontent.com/jqlang/jq/mast
 ARG BOOTSTRAP_LICENSE
 ARG CONFIG
 
+RUN yum-config-manager --add-repo https://repo.mongodb.org/yum/redhat/9/mongodb-org/8.0/x86_64/ && \
+    yum-config-manager --save --setopt=repo.mongodb.org_yum_redhat_9_mongodb-org_8.0_x86_64_.gpgkey=https://www.mongodb.org/static/pgp/server-8.0.asc && \
+    yum install -y mongodb-mongosh && \
+    yum -y clean all
+
+ADD scripts/mongosh /usr/local/bin/mongosh
+
 RUN yum-config-manager --add-repo https://release.memsql.com/$(echo "${CONFIG}" | jq -r .channel)/rpm/x86_64/repodata/memsql.repo && \
     yum install -y \
     singlestore-client-$(echo "${CONFIG}" | jq -r .client) \

--- a/scripts/mongosh
+++ b/scripts/mongosh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -uf
+
+# shellcheck disable=SC2034
+# CURRENT_DIR is used in the replacements of BIN_PATH and PLUGIN_DIR placeholders
+CURRENT_DIR=$(dirname "$(readlink -f "${0}")")
+
+exec "/usr/bin/mongosh" \
+  -u "root" \
+  -p "${ROOT_PASSWORD}" \
+  "${@}" \
+  "mongodb://127.0.0.1:27017/?authMechanism=PLAIN&tls=true&loadBalanced=true"

--- a/scripts/mongosh
+++ b/scripts/mongosh
@@ -10,4 +10,4 @@ exec "/usr/bin/mongosh" \
   -u "root" \
   -p "${ROOT_PASSWORD}" \
   "${@}" \
-  "mongodb://127.0.0.1:27017/?authMechanism=PLAIN&tls=true&loadBalanced=true"
+  "mongodb://localhost:27017/?authMechanism=PLAIN&loadBalanced=true"


### PR DESCRIPTION
I would like to add the `mongosh` client to the container so that it is easy to run a client against the mongo port just like we currently do with the SingleStoreDB port using `singlestore`.