### PR TITLE
Add singlestore / mongosh clients that authenticate using env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,8 @@ RUN yum-config-manager --add-repo https://repo.mongodb.org/yum/redhat/9/mongodb-
     yum -y clean all
 
 ADD scripts/mongosh /usr/local/bin/mongosh
+ADD scripts/mongosh-auth /usr/local/bin/mongosh-auth
+ADD scripts/singlestore-auth /usr/local/bin/singlestore-auth
 
 RUN yum-config-manager --add-repo https://release.memsql.com/$(echo "${CONFIG}" | jq -r .channel)/rpm/x86_64/repodata/memsql.repo && \
     yum install -y \

--- a/scripts/mongosh-auth
+++ b/scripts/mongosh-auth
@@ -8,5 +8,6 @@ CURRENT_DIR=$(dirname "$(readlink -f "${0}")")
 
 exec "/usr/bin/mongosh" \
   -u root \
+  -p "${ROOT_PASSWORD}" \
   "${@}" \
   "mongodb://localhost:27017/?authMechanism=PLAIN&loadBalanced=true"

--- a/scripts/singlestore-auth
+++ b/scripts/singlestore-auth
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -uf
+
+# shellcheck disable=SC2034
+# CURRENT_DIR is used in the replacements of BIN_PATH and PLUGIN_DIR placeholders
+CURRENT_DIR=$(dirname "$(readlink -f "${0}")")
+
+exec "/usr/lib/singlestore-client/singlestore-client" \
+  --no-defaults \
+  --plugin-dir="/usr/lib/singlestore-client/plugin" \
+  --protocol=tcp \
+  --prompt="singlestore> " \
+  -u root \
+  -P 3306 \
+  --password="${ROOT_PASSWORD}" \
+  "${@}"


### PR DESCRIPTION
The current sinlgestore client in the container requires that you specify a password even though the root password is already available as an env var. I've added a new client interface (singlestore-auth) and new mongosh client (mongosh-auth) that use the existing password so that you do not get prompted for it when using these interfaces.