### PR TITLE
[singlestoredb-dev-image] Bumps the engine version to 8.9.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.49 - 2025-03-19
+- SingleStoreDB Version 8.9.14
+
 ## 0.2.48 - 2025-03-12
 - SingleStoreDB Version 8.9.13
 

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "channel": "production",
-  "server": "8.9.13-4ba4cb61d5",
+  "server": "8.9.14-5fd31e7c54",
   "toolbox": "1.17.4",
   "client": "1.0.7",
   "studio": "4.0.14",


### PR DESCRIPTION
chore(release): bump version to 8.9.14