### PR TITLE
[singlestoredb-dev-image] Bumps the engine version to 8.9.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.50 - 2025-03-25
+- SingleStoreDB Version 8.9.17
+
 ## 0.2.49 - 2025-03-19
 - SingleStoreDB Version 8.9.14
 

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "channel": "production",
-  "server": "8.9.14-5fd31e7c54",
+  "server": "8.9.17-4940fb8984",
   "toolbox": "1.17.4",
   "client": "1.0.7",
   "studio": "4.0.14",


### PR DESCRIPTION
Summary:

**Design doc/spec**:
**Docs impact**: none
**Preliminary Reviewer(s)**:
**Final Reviewer**:
Test Plan:

Reviewers:

CC:

JIRA Issues: