### PR TITLE
Update switch-version.sh

### DIFF
--- a/scripts/switch-version.sh
+++ b/scripts/switch-version.sh
@@ -7,11 +7,7 @@ if [ -z "${VERSION}" ]; then
     exit 1
 fi
 
-LICENSE="${2:-}"
-if [ -z "${LICENSE}" ]; then
-    echo "Usage: $0 <version> <license>"
-    exit 1
-fi
+LICENSE="BDBkMTllNTkxYmJlNDRlN2U5ZWYyM2YzZDRmN2YwY2FmAAAAAAAAAAAEAAAAAAAAACgwNQIZALfDACVybqBaHxUHdjHEfTPECqOfdquMVwIYUKDroCKPtLk0qAuwzFHh5L6GxwTw9vDzAA=="
 
 sdb-admin -y delete-node --all
 sdb-deploy -y uninstall --all-versions


### PR DESCRIPTION
Summary:
Fixed switch-version.sh braking without a license key, added a hardcoded license key from start.sh.

CC: @eli-memsql

Slack thread: https://memsql.slack.com/archives/C02G51BAJ/p1745340824307749