### PR TITLE
chore: bump the engine version to 9.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## 0.2.53 - 2025-06-18
+## 0.2.55 - 2025-06-26
+- SingleStoreDB Version 9.0.6
+
+## 0.2.54 - 2025-06-18
 - SingleStoreDB Version 9.0.5
 
 ## 0.2.53 - 2025-06-11

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "channel": "production",
   "engine_channel": "rc",
-  "server": "9.0.5-eb23785ec3",
+  "server": "9.0.6-f9163bfd6d",
   "toolbox": "1.18.2",
   "client": "1.0.7",
   "studio": "4.0.14",


### PR DESCRIPTION
bump the engine version to 9.0.6