### PR TITLE
fix: enable auto-tag to fetch with full history

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,7 @@ env:
 
 jobs:
   auto-tag:
-    # TEMP
-    # if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    if: github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
 
     steps:
@@ -45,9 +43,8 @@ jobs:
           
           echo "Creating tag: $TAG_NAME"
 
-          # TEMP
-          # git tag "$TAG_NAME"
-          # git push origin "$TAG_NAME"
+          git tag "$TAG_NAME"
+          git push origin "$TAG_NAME"
           
           echo "Successfully created and pushed tag: $TAG_NAME"
 


### PR DESCRIPTION
The change fixes the failure in the auto-tag job, where, in the recent runs, I found that the tag wasn't listed properly. The reason was the default checkout action did not include fetching with tags. Add an option to fetch with depth `0`, so that it will include full history with tags.