### PR TITLE
ci: fix publish-image action when a tag is automatically published by auto-tag workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,6 +116,7 @@ jobs:
 
     needs:
       - build-and-test-image
+      - auto-tag
 
     steps:
       - name: Checkout source


### PR DESCRIPTION
Currently the GH actions workflow is set up in a way to automatically push a tag when a PR branch containing changes to `config.json` is done. The intention was to automatically create/publish a new image, instead of a user intervention.

This workflow happens, but the `publish-image` step didn't run because it was only checking for 

```
if: github.ref_type == 'tag' 
```

Which won't be applicable when a PR is merged to the default branch. Now added a condition to ensure the condition is satisfied for PR merge events as well.