### PR TITLE
fix: remove auto-tag job that creates a new tag on merge to default branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,6 @@ jobs:
 
     needs:
       - build-and-test-image
-      - auto-tag
 
     steps:
       - name: Checkout source


### PR DESCRIPTION
I added an auto-tag job that pushes a tag object on merge to default branch, so that it can kick off the build push action immediately. It is not working as expected. Backing it out and work on a proper fix.