### PR TITLE
ci: enable auto-tag job for automatic tag pushes on merges to default branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,39 @@ env:
   SINGLESTORE_LICENSE: ${{ secrets.SINGLESTORE_LICENSE }}
 
 jobs:
+  auto-tag:
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history and tags
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v46
+        with:
+          files: |
+            config.json
+
+      - name: Extract version and create tag
+        if: steps.changed-files.outputs.only_changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Extract most recent tag published and increment one top of it.
+          TAG_NAME=$(git describe --tags --abbrev=0 | awk -F. -v OFS=. '{$NF += 1 ; print}')
+          
+          echo "Creating tag: $TAG_NAME"
+
+          git tag "$TAG_NAME"
+          git push origin "$TAG_NAME"
+          
+          echo "Successfully created and pushed tag: $TAG_NAME"
+
   build-and-test-image:
     runs-on: ubuntu-latest
 
@@ -76,6 +109,8 @@ jobs:
           ${{steps.grype.outputs.cmd}} --only-fixed singlestore-labs/singlestoredb-dev
 
   publish-image:
+    # Run if someone pushes a tag manually (or)
+    # Run when auto-tag creates a tag (which triggers a new workflow run with github.ref_type == 'tag')
     if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Added GH workflow fix to automatically publish a new git tag on push to default branch, if `config.json` was modified.

Previously, the release engineers manually pushed the Git tag containing their updates to `config.json`, this worked well thus far. Now starting this week, Freya will automatically create PRs in this repo with updates to `config.json`, when a major engine release is made. This workflow will eliminate the need for manual action to push the tag and automatically publish the recent Docker image.