### PR TITLE
ci: fix conditional check in changed-files action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
             config.json
 
       - name: Extract version and create tag
-        if: steps.changed-files.outputs.only_changed
+        if: steps.changed-files.outputs.only_changed == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
The change resolves an issue with the usage of `changed_files` GH action used in the workflow. The method `only_changed` returns a string type and not a boolean.