### PR TITLE
ci: enable changed-files action to correctly identify files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
             config.json
 
       - name: Extract version and create tag
-        if: steps.changed-files.outputs.only_changed == 'true'
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
The auto-tag job was failing to create tags when `config.json` was modified alongside other files (e.g., `CHANGELOG.md`)

The workflow used `only_changed` output from `tj-actions/changed-files`, which returns true only when the specified file changed and no other files changed. This caused the tag creation to be skipped when `config.json` was updated as part of a multi-file commit.

Changed the condition to use `any_changed` instead:
