### PR TITLE
Fix typo in README for init.sql file location

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ This Docker image has a number of volume mount points in addition to `/data`. Th
 
 ## How to initialize this container with a SQL file?
 
-When this Docker image starts for the first time, it checks to see if an `init.sql` file exists in its filesystem. The default location is `/init.sh`, but it can be customized via the `INIT_SQL` environment variable. If `init.sql` is found, the container will run it against the database as soon as SingleStore is ready.
+When this Docker image starts for the first time, it checks to see if an `init.sql` file exists in its filesystem. The default location is `/init.sql`, but it can be customized via the `INIT_SQL` environment variable. If `init.sql` is found, the container will run it against the database as soon as SingleStore is ready.
 
 One way to do this is by mounting an `init.sql` from your machine into the container using the `-v` flag. Here is an example of doing this:
 


### PR DESCRIPTION
Corrected the default location for _init.sql_ in the description above the example.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only correction with no runtime or configuration behavior changes.
> 
> **Overview**
> Fixes a documentation typo in the **initialize with SQL file** section: the default filesystem path for `init.sql` is now documented as **`/init.sql`** instead of **`/init.sh`**, matching the `INIT_SQL` override and the example volume mount in the same section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9790519a74d961bcfaadd7b1c39d26e8dc82ce48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->